### PR TITLE
Added support for building a Virtual Console patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # roms
 *.gbc
 *.gb
+*.patch
 
 # for any of the poor souls with save game files in their working directory
 *.sgm

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -20,6 +20,7 @@ DoBattleTransition:
 	ld hl, hVBlank
 	ld a, [hl]
 	push af
+.VC_FPA_link_fight_begin::
 	ld [hl], $1
 
 .loop
@@ -57,6 +58,7 @@ DoBattleTransition:
 	ld a, 1 ; unnecessary bankswitch?
 	ld [rSVBK], a
 	pop af
+.VC_FPA_link_fight_End4::
 	ld [hVBlank], a
 	call DelayFrame
 	ret
@@ -309,6 +311,7 @@ StartTrainerBattle_Flash:
 	db %00000001 ; 0001
 
 StartTrainerBattle_SetUpForWavyOutro:
+.VC_FPA_link_fight_End0::
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
 	ld [rSVBK], a
@@ -367,6 +370,7 @@ StartTrainerBattle_SineWave:
 	ret
 
 StartTrainerBattle_SetUpForSpinOutro:
+.VC_FPA_link_fight_End1::
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
 	ld [rSVBK], a
@@ -509,6 +513,7 @@ ENDM
 .wedge5 db 4, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, -1
 
 StartTrainerBattle_SetUpForRandomScatterOutro:
+.VC_FPA_link_fight_End2::
 	farcall Function5602
 	ld a, BANK(wLYOverrides)
 	ld [rSVBK], a
@@ -758,6 +763,7 @@ StartTrainerBattle_DrawSineWave:
 	calc_sine_wave
 
 StartTrainerBattle_ZoomToBlack:
+.VC_FPA_link_fight_End3::
 	farcall Function5602
 	ld de, .boxes
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8924,6 +8924,7 @@ InitBattleDisplay:
 	predef PlaceGraphic
 	xor a
 	ld [hWY], a
+.VC_fight_begin::
 	ld [rWY], a
 	call WaitBGMap
 	call HideSprites

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -58,12 +58,20 @@ BattleAnimRunScript:
 	farcall CheckBattleScene
 	jr c, .disabled
 
+.VC_FPA_001_Begin::
+.VC_FPA_002_Begin::
+.VC_FPA_003_Begin::
+.VC_FPA_004_Begin::
+.VC_FPA_005_Begin::
+.VC_FPA_006_Begin::
+.VC_FPA_007_Begin::
 	call BattleAnimClearHud
 	call RunBattleAnimScript
 
 	call BattleAnimAssignPals
 	call BattleAnimRequestPals
 
+.VC_FPA_001_End::
 	xor a
 	ld [hSCX], a
 	ld [hSCY], a
@@ -666,6 +674,7 @@ BattleAnimCmd_5GFX:
 .loop
 	ld a, [wBattleAnimTemp0]
 	cp (vTiles1 - vTiles0) / $10 - $31
+.VC_FPA_042801_Begin::
 	ret nc
 	call GetBattleAnimByte
 	ld [hli], a

--- a/engine/events/print_unown.asm
+++ b/engine/events/print_unown.asm
@@ -74,7 +74,12 @@ _UnownPrinter:
 	jr nz, .pressed_b
 
 	ld a, [hJoyPressed]
+.VC_print_forbid_1::
+if DEF(_CRYSTALVC)
+	and 0
+else
 	and A_BUTTON
+endc
 	jr nz, .pressed_a
 
 	call .LeftRight

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1051,6 +1051,7 @@ endr
 .FinalPush:
 	ld hl, MltReq1Packet
 	call PushSGBPals
+.VC_Network_RESET::
 	jp SGBDelayCycles
 
 SGBBorder_PushBGPals:

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -66,7 +66,12 @@ Gen2ToGen1LinkComms:
 .player_1
 	ld de, MUSIC_NONE
 	call PlayMusic
+.VC_NetworkDelay1::
+if DEF(_CRYSTALVC)
+	ld c, 26
+else
 	ld c, 3
+endc
 	call DelayFrames
 	xor a
 	ld [rIF], a
@@ -75,18 +80,21 @@ Gen2ToGen1LinkComms:
 	ld hl, wd1f3
 	ld de, wEnemyMonSpecies
 	ld bc, $11
+.VC_Network358::
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wLinkData
 	ld de, wOTPlayerName
 	ld bc, $1a8
+.VC_Network359::
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wLink_c608
 	ld de, wTrademons
 	ld bc, wTrademons - wLink_c608
+.VC_Network364::
 	call Serial_ExchangeBytes
 	xor a
 	ld [rIF], a
@@ -210,7 +218,12 @@ Gen2ToGen2LinkComms:
 .Player1:
 	ld de, MUSIC_NONE
 	call PlayMusic
+.VC_NetworkDelay4::
+if DEF(_CRYSTALVC)
+	ld c, 26
+else
 	ld c, 3
+endc
 	call DelayFrames
 	xor a
 	ld [rIF], a
@@ -219,18 +232,21 @@ Gen2ToGen2LinkComms:
 	ld hl, wd1f3
 	ld de, wEnemyMonSpecies
 	ld bc, $11
+.VC_Network360::
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wLinkData
 	ld de, wOTPlayerName
 	ld bc, $1c2
+.VC_Network361::
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wLink_c608
 	ld de, wTrademons
 	ld bc, wTrademons - wLink_c608
+.VC_Network362::
 	call Serial_ExchangeBytes
 	ld a, [wLinkMode]
 	cp LINK_TRADECENTER
@@ -238,6 +254,7 @@ Gen2ToGen2LinkComms:
 	ld hl, wc9f4
 	ld de, wcb84
 	ld bc, $186
+.VC_Network363::
 	call ExchangeBytes
 
 .not_trading
@@ -1562,6 +1579,7 @@ Function28b22:
 	ld [rSC], a
 	ld a, (1 << rSC_ON) | 1
 	ld [rSC], a
+.VC_ret_heya::
 	ret
 
 Unreferenced_Function28b42:
@@ -1932,6 +1950,7 @@ LinkTrade:
 	ld de, String28ebd
 	call PlaceString
 	farcall Link_WaitBGMap
+.VC_save_game_end::
 	ld c, 50
 	call DelayFrames
 	ld a, [wLinkMode]
@@ -2084,7 +2103,12 @@ Function29c67:
 	ret
 
 EnterTimeCapsule:
+.VC_NetworkDelay2::
+if DEF(_CRYSTALVC)
+	ld c, 26
+else
 	ld c, 10
+endc
 	call DelayFrames
 	ld a, $4
 	call Link_EnsureSync
@@ -2141,6 +2165,7 @@ WaitForOtherPlayerToExit:
 	ld [hl], a
 	ld [hVBlank], a
 	ld [wLinkMode], a
+.VC_term_exit::
 	ret
 
 SetBitsForLinkTradeRequest:
@@ -2205,6 +2230,7 @@ WaitForLinkedFriend:
 	ld a, (0 << rSC_ON) | 0
 	ld [rSC], a
 	ld a, (1 << rSC_ON) | 0
+.VC_linkCable_fake_begin::
 	ld [rSC], a
 	ld a, [wLinkTimeoutFrames]
 	dec a
@@ -2290,7 +2316,12 @@ Function29dba:
 	ld a, $6
 	ld [wPlayerLinkAction], a
 	ld hl, wLinkTimeoutFrames
+.VC_NetworkDelay6::
+if DEF(_CRYSTALVC)
+	ld a, $3
+else
 	ld a, $1
+endc
 	ld [hli], a
 	ld [hl], $32
 	call Link_CheckCommunicationError
@@ -2311,6 +2342,7 @@ Function29dba:
 Link_CheckCommunicationError:
 	xor a
 	ld [hSerialReceivedNewData], a
+.VC_linkCable_fake_end::
 	ld a, [wLinkTimeoutFrames]
 	ld h, a
 	ld a, [wLinkTimeoutFrames + 1]
@@ -2341,6 +2373,7 @@ Link_CheckCommunicationError:
 .CheckConnected:
 	call WaitLinkTransfer
 	ld hl, wLinkTimeoutFrames
+.VC_Network_RECHECK::
 	ld a, [hli]
 	inc a
 	ret nz
@@ -2349,7 +2382,12 @@ Link_CheckCommunicationError:
 	ret
 
 .AcknowledgeSerial:
+.VC_NetworkDelay3::
+if DEF(_CRYSTALVC)
+	ld b, 26
+else
 	ld b, 10
+endc
 .loop
 	call DelayFrame
 	call LinkDataReceived
@@ -2376,8 +2414,10 @@ TryQuickSave:
 	ld a, [wd265]
 	push af
 	farcall Link_SaveGame
+.VC_linkCable_block_input::
 	ld a, TRUE
 	jr nc, .return_result
+.VC_linkCable_block_input2::
 	xor a ; FALSE
 .return_result
 	ld [wScriptVar], a
@@ -2414,6 +2454,7 @@ CheckBothSelectedSameRoom:
 	ret
 
 TimeCapsule:
+.VC_to_play2_mons1::
 	ld a, LINK_TIMECAPSULE
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2424,6 +2465,7 @@ TimeCapsule:
 	ret
 
 TradeCenter:
+.VC_to_play2_trade::
 	ld a, LINK_TRADECENTER
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2434,6 +2476,7 @@ TradeCenter:
 	ret
 
 Colosseum:
+.VC_to_play2_battle::
 	ld a, LINK_COLOSSEUM
 	ld [wLinkMode], a
 	call DisableSpriteUpdates
@@ -2448,6 +2491,7 @@ CloseLink:
 	ld [wLinkMode], a
 	ld c, 3
 	call DelayFrames
+.VC_room_check::
 	jp Link_ResetSerialRegistersAfterLinkClosure
 
 FailedLinkToPast:

--- a/engine/link/mystery_gift.asm
+++ b/engine/link/mystery_gift.asm
@@ -9,15 +9,24 @@ DoMysteryGift:
 	call WaitBGMap
 	farcall PrepMysteryGiftDataToSend
 	call MysteryGift_ClearTrainerData
+.VC_infrared_fake_0::
+if DEF(_CRYSTALVC)
+	; Same bank. And there I thought they'd have learned by now...
+	farcall StagePartyDataForMysteryGift
+	call MysteryGift_ClearTrainerData
+	nop
+else
 	ld a, $2
 	ld [wca01], a
 	ld a, $14
 	ld [wca02], a
+endc
 	ld a, [rIE]
 	push af
 
 	call Function104a95
 
+.VC_infrared_fake_4::
 	ld d, a
 	xor a
 	ld [rIF], a
@@ -226,6 +235,26 @@ DoMysteryGift:
 	jp CloseSRAM
 
 Function104a95:
+.VC_infrared_fake_2:: ; hook
+.VC_infrared_fake_1:: ; patch
+if DEF(_CRYSTALVC)
+	ld d, $ef
+.loop
+	dec d
+	ld a, d
+	or a
+	jr nz, .loop
+.VC_infrared_fake_3:: ; hook
+	nop
+	cp $10
+.loop2 ; same location as original .loop2
+	ret z
+	nop
+	nop
+	cp $6c
+	jr nz, Function104a95
+	ret
+else
 	di
 	farcall ClearChannels
 	call Function104d5e
@@ -234,6 +263,7 @@ Function104a95:
 	call Function104d96
 	call Function104ddd
 	ld a, [hMGStatusFlags]
+endc
 	cp $10
 	jp z, Function104bd0
 	cp $6c

--- a/engine/menus/menu.asm
+++ b/engine/menus/menu.asm
@@ -364,7 +364,9 @@ Menu_WasButtonPressed:
 	call GetMenuJoypad
 	and a
 	ret z
+.VC_print_forbid_3::
 	scf
+.VC_print_forbid_2::
 	ret
 
 _2DMenuInterpretJoypad:

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -161,6 +161,8 @@ AddHallOfFameEntry:
 	ld bc, wHallOfFamePokemonListEnd - wHallOfFamePokemonList + 1
 	call CopyBytes
 	call CloseSRAM
+; Causes the emulator to set sMobileEventIndex and sMobileEventIndexBackup to $b
+.VC_BiographySave_ret::
 	ret
 
 SaveGameData:

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -426,6 +426,7 @@ Script_yesorno:
 	ld a, TRUE
 .no
 	ld [wScriptVar], a
+.VC_E_YESNO::
 	ret
 
 Script_loadmenu:

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -356,6 +356,7 @@ Pokedex_UpdateDexEntryScreen:
 	ld a, [hl]
 	and B_BUTTON
 	jr nz, .return_to_prev_screen
+.VC_print_forbid_5::
 	ld a, [hl]
 	and A_BUTTON
 	jr nz, .do_menu_action

--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -52,7 +52,12 @@ ReadAnyMail:
 	ld a, [hJoyPressed]
 	and A_BUTTON | B_BUTTON | START
 	jr z, .loop
+.VC_print_forbid_4::
+if DEF(_CRYSTALVC)
+	and 0
+else
 	and START
+endc
 	jr nz, .pressed_start
 	ret
 

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -286,6 +286,7 @@ Serial_SyncAndExchangeNybble::
 ; One "giant" leap for machinekind
 
 WaitLinkTransfer::
+.VC_send_send_buf2::
 	ld a, $ff
 	ld [wOtherPlayerLinkAction], a
 .loop
@@ -313,14 +314,24 @@ WaitLinkTransfer::
 	inc a
 	jr z, .loop
 
+.VC_Network10::
+if DEF(_CRYSTALVC)
+	ld b, 26
+else
 	ld b, 10
+endc
 .receive
 	call DelayFrame
 	call LinkTransfer
 	dec b
 	jr nz, .receive
 
+.VC_Network11::
+if DEF(_CRYSTALVC)
+	ld b, 26
+else
 	ld b, 10
+endc
 .acknowledge
 	call DelayFrame
 	call LinkDataReceived
@@ -329,6 +340,7 @@ WaitLinkTransfer::
 
 	ld a, [wOtherPlayerLinkAction]
 	ld [wOtherPlayerLinkMode], a
+.VC_send_send_buf2_ret::
 	ret
 
 LinkTransfer::

--- a/mobile/mobile_40.asm
+++ b/mobile/mobile_40.asm
@@ -1531,7 +1531,10 @@ Function1009f3:
 _LinkBattleSendReceiveAction:
 	call .StageForSend
 	ld [wd431], a
-	farcall PlaceWaitingText
+	ld a, BANK(PlaceWaitingText)
+	ld hl, PlaceWaitingText
+.VC_send_byt2::
+	rst FarCall
 	ld a, [wLinkMode]
 	cp LINK_MOBILE
 	jr nz, .not_mobile
@@ -1585,20 +1588,33 @@ _LinkBattleSendReceiveAction:
 	inc a
 	jr z, .waiting
 
+.VC_send_byt2_ret:: ; hook
+.VC_send_byt2_wait:: ; patch
+if DEF(_CRYSTALVC)
+	ld b, 26
+else
 	ld b, 10
+endc
 .receive
 	call DelayFrame
 	call LinkTransfer
 	dec b
 	jr nz, .receive
 
+.VC_send_dummy:: ; hook
+.VC_send_dummy_wait:: ; patch
+if DEF(_CRYSTALVC)
+	ld b, 26
+else
 	ld b, 10
+endc
 .acknowledge
 	call DelayFrame
 	call LinkDataReceived
 	dec b
 	jr nz, .acknowledge
 
+.VC_send_dummy_end::
 	ld a, [wOtherPlayerLinkAction]
 	ld [wBattleAction], a
 	ret

--- a/pokecrystalvc.patch.template
+++ b/pokecrystalvc.patch.template
@@ -1,0 +1,734 @@
+﻿/* vim:set noeol nofixeol ff=dos:
+
+This file is preprocessed by tools/make_patch
+It reads the name of a label in the [] of this file,
+  finds its offset in the patched ROM,
+  and replaces any "command" that follows in this file with the appropriate values.
+
+Of note is that the preprocessor is very stupid,
+  and won't check if the offsets in the original ROM differ with those
+  in the patched ROM. It also won't tell you if you didn't catch all of
+  the differences between the ROMs.
+
+The structure of a command is the following:
+  {{Command:argument1:argument2...}}
+
+The possible commands are as follows:
+  Address:
+    Replaced by the address of the label.
+      argument 1: Offset from label. Can be anything parsable with strtol(3).
+      argument 2: Amount of zeroes to prefix it with...
+
+  Patch:
+    Replaced by the byte found at the label in the patched ROM.
+      argument 1: Offset from label. Can be anything parsable with strtol(3).
+      argument 2: If "big", writes a string of bytes starting from the label until it finds a byte that matches with the original ROM.
+
+  Constant:
+    Replaced by the hexadecimal value of a constant in an assembly file.
+    This can be through either the "EQU" or the "const" directives.
+      argument 1: Path to the assembly file.
+      argument 2: Name of the constant.
+
+*/;Format Sample
+;[xxxx]			;User-defined Name (Max:31 chars)
+;Mode = 1		;1:Fixcode; 2:Fixvalue; 3:Mask; 4:Palette; 5:Double Frame Buffer
+;Type = 0		;0:Begin 1:End
+;Index = 0		;Index
+;Address = x1F8000	;ROM Address
+;MemAddress = x2000	;RAM Address
+;Fixcode = 0		;Mode1: Fixed Rom Code; Mode2: Fixed Value
+;DelayFrame = 0		;Delay Frame
+;FadeFrame = 0		;Fade Frame 0:Off
+;DarkEnable0 = 0	;0:Off, 1:On (for Normal Mode)
+;ReduceEnable0 = 0	;0:Off, 1:On (for Normal Mode)
+;MotionBEnable0 = 0	;0:Off, 1:Black Fade, 2:, 3:Frame Blend (for Normal Mode)
+;Dark0 = 10		;0~10 (for Normal Mode)
+;ReduceColorR0 = 0	;0~31 (for Normal Mode)
+;ReduceColorG0 = 0	;0~31 (for Normal Mode)
+;ReduceColorB0 = 0	;0~31 (for Normal Mode)
+;MotionBlur0 = 31	;0~31 (for Normal Mode)
+;DarkEnable1 = 0	;0:Off, 1:On (for Green Mode)
+;ReduceEnable1 = 0	;0:Off, 1:On (for Green Mode)
+;MotionBEnable1 = 0	;0:Off, 1:Black Fade, 2:, 3:Frame Blend (for Green Mode)
+;Dark1 = 10		;0~10 (for Green Mode)
+;ReduceColorR1 = 0	;0~31 (for Green Mode)
+;ReduceColorG1 = 0	;0~31 (for Green Mode)
+;ReduceColorB1 = 0	;0~31 (for Green Mode)
+;MotionBlur1 = 31	;0~31 (for Green Mode)
+;PaletteX = c31,31,31	;X:0~15, cR,G,B (0~31)
+
+[Network10]
+Mode = 1
+Address = {{Address:1:1}}
+Fixcode = {{Patch:1}}
+
+[Network11]
+Mode = 1
+Address = {{Address:1:1}}
+Fixcode = {{Patch:1}}
+
+[send_send_buf2]
+Mode = 2
+Address = {{Address::1}}
+Type = 29
+
+[send_send_buf2_ret]
+Mode = 2
+Address = {{Address::1}}
+Type = 30
+
+[Network358]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network359]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network364]
+Mode = 2
+Address = {{Address}}
+;fix pokemon ?? in name
+Type = 26
+
+[Network360]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network361]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network362]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network363]
+Mode = 2
+Address = {{Address}}
+Type = 4
+
+[Network_RECHECK]
+Mode = 2
+Address = {{Address}}
+Type = 7
+
+[send_byt2]
+Mode = 2
+Address = {{Address}}
+Type = 31
+
+[send_byt2_ret]
+Mode = 2
+Address = {{Address}}
+Type = 32
+
+[send_byt2_wait]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+[send_dummy]
+Mode = 2
+Address = {{Address}}
+Type = 33
+
+[send_dummy_wait]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}} 
+
+[send_dummy_end]
+Mode = 2
+Address = {{Address}}
+Type = 34
+
+[NetworkDelay1]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+[NetworkDelay2]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+[NetworkDelay3]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+[NetworkDelay4]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+[NetworkDelay6]
+Mode = 1
+Address = {{Address:1}}
+Fixcode = {{Patch:1}}
+
+;no use[Network_STOP]
+;Mode = 2
+;Address = 0xF4D34
+;Type = 8
+
+;no use[Network_END]
+;Mode = 2
+;Address = 0xF4D3C
+;Type = 9
+
+[Network_RESET]
+Mode = 2
+Address = {{Address::1}}
+Type = 10
+
+[E_YESNO]
+Mode = 2
+Address = {{Address}}
+Type = 15
+
+[linkCable fake begin]
+Mode = 2
+Address = {{Address}}
+Type = 16
+
+[linkCable fake end]
+Mode = 2
+Address = {{Address}}
+Type = 17  
+
+;MURIYARI
+[linkCable block input]
+Mode = 2
+Address = {{Address}}
+Type = 18
+[linkCable block input2]
+Mode = 2
+Address = {{Address}}
+Type = 24
+[save game end]
+Mode = 2
+Address = {{Address}}
+Type = 20
+[term_exit]
+Mode = 2
+Address = {{Address}}
+Type = 25
+[room_check]
+Mode = 2
+Address = {{Address}}
+Type = 27
+[to_play2_mons1]
+Mode = 2
+Address = {{Address}}
+Type = 11
+[to_play2_trade]
+Mode = 2
+Address = {{Address}}
+Type = 12
+[to_play2_battle]
+Mode = 2
+Address = {{Address}}
+Type = 13
+[ret_heya]
+Mode = 2
+Address = {{Address}}
+Type = 14
+
+
+
+
+
+;ROM:3FBCD                 ld      b, $3E ; '>'
+;ROM:3FBCF                 inc     de
+;ROM:3FBD0                 call    unk_2D55
+;ROM:3FBD3                 xor     a
+;ROM:3FBD4                 ld      [byte_FFD2], a
+;ROM:3FBD6                 ld      [byte_FF4A], a
+;ROM:3FBD8                 call    unk_31C2
+;ROM:3FBDB                 call    unk_2FE2
+;
+;ROM:3FBCD:  06 3E 13 CD
+
+;0003fbb5h: 06 3E 13 CD                                     ; .>.?
+
+[fight begin]                        
+Mode = 11                       
+Type = 0                        
+Index = 1                       
+Address = {{ADDREss}}            
+Fixcode=a1:90   /* Not really sure what this fixcode does. */     
+              
+;12 1b 0b 79 b0  find next C9
+/*
+    This is ran whenever you enter the Hall of Fame.
+    It sets sMobileEventIndex and sMobileEventIndexBackup to $b.
+    essentially enabling the Celebi event.
+*/[BiographySave_ret]
+Mode = 2
+Address = {{Address}}
+Type = 60
+
+
+; print forbid 1
+;ROM:1758D                 ld      a, [byte_FFA9]
+;ROM:1758F                 and     2
+;ROM:17591                 jr      nz, unk_75B4
+;ROM:17593                 ld      a, [byte_FFA9]
+;ROM:17595                 and     1                      ;e6 01
+;ROM:17597                 jr      nz, unk_75A1
+;    
+; change "and 1" to "and 0"
+;00017595h: E6 01 20 08 CD BF 75 CD 2E 03 18 E9 FA 57 CE F5 ; ? .涂u?..辁W熙
+;00016c76h: E6 01 20 08 CD A0 6C CD 5A 04 18 E9 FA 63 CF F5 ; ? .蜖l蚙..辁c硝
+[print forbid 1]                                                   
+Mode = 1                                                                                                                  
+Address = {{address}}
+Fixcode={{patch::big}}      
+
+
+                            
+[print forbid 2]                                                                           
+Mode = 6                                                                                       
+Type = 0                                                                                       
+Address = {{address}}                                                                        
+MemAddress=0x{{constant:hram.asm:hJoyPressed}}                                                                           
+Fixcode=a1:00   /* Clears pressed keys? */                                                                               
+ConditionType = 0                                                                              
+ConditionValueA = a20: 71 cf 72 cf 73 cf 74 cf 74 cf a9 cf a7 ff a7 ff a7 ff a7 ff                   
+ConditionValueB = a20: 00 00 00 00 00 00 03 00 04 00 00 00 05 00 05 00 05 00 05 00                   
+ConditionValueC = a20: dd 00 d3 00 01 00 00 00 0f 00 03 00 80 00 40 00 02 00 00 00                   
+    
+; -----ddddfffffff99999ccccc77777----0xd9c7 no ..............Mem Write: pc32 = 0x230b addr = 0xd9c7 value = 0x8
+; 0xd9c7 is the room number.
+
+
+[print forbid 3]                                                          
+Mode = 6                                                                      
+Type = 0                                                                      
+Address = {{address}}                                                           
+MemAddress=0x{{constant:hram.asm:hJoyPressed}}                                                            
+Fixcode=a1:00   /* Clears pressed keys? */                                                              
+ConditionType = 0                                                             
+ConditionValueA = a26: 71 cf 72 cf 73 cf 74 cf a9 cf b5 dc b6 dc b7 dc b8 dc a7 ff a7 ff a7 ff a7 ff  
+ConditionValueB = a26: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 05 00 05 00 05 00 05 00  
+ConditionValueC = a26: af 00 df 00 00 00 00 00 01 00 16 00 08 00 04 00 02 00 80 00 40 00 02 00 00 00  
+
+                                               
+;ROM:BB29C                 call    unk_934       
+;ROM:BB29F                 ld      a, [byte_FFA9]                                                                                                                                                                         
+;ROM:BB2A1                 and     $B            
+;ROM:BB2A3                 jr      z, unk_B29C   
+;ROM:BB2A5                 and     8             
+;ROM:BB2A7                 jr      nz, unk_B2AA  
+;ROM:BB2A9                 ret    
+; 000bb2a5h: E6 08 20 01       
+; 000b92a3h: E6 08 20 01                                     ; ? .                           
+; change "and 8" to "and 0"                                                      
+[print forbid 4]                                                  
+Mode = 1                                                          
+Address = {{address}}                                          
+Fixcode={{patch::big}}            
+
+
+;ROM:401D6                 call    unk_50A5                                         
+;ROM:401D9                 ld      hl, $FFA9  
+;ROM:401DC                 ld      a, [hl]    
+;ROM:401DD                 and     2          
+;ROM:401DF                 jr      nz, unk_1F8
+;ROM:401E1                 ld      a, [hl]    
+;ROM:401E2                 and     1          
+;ROM:401E4                 jr      nz, unk_1EE
+;ROM:401E6                 call    unk_4562   
+;ROM:401E9                 ret     nc         
+;ROM:401EA                 call    unk_4114   
+;ROM:401ED                 ret       
+; -----6666666666ddddddddd88888----0xc6d8 no ..............Mem Write: pc32 = 0x4109b addr = 0xc6d8 value = 0x0
+
+;00040266h: 7E E6 01 20 08                                  ; ~? .                                 
+[print forbid 5]                                                                                           
+Mode = 6                                                                                          
+Type = 0                                                                                          
+Address = {{address}}                                                                            
+MemAddress=0x{{constant:hram.asm:hJoyPressed}}                                                                                 
+Fixcode=a1:00   /* Clears pressed keys? */                                                                                  
+ConditionType = 0                                                                                 
+ConditionValueA = a18: 71 cf 72 cf 73 cf 74 cf d8 c7 a7 ff a7 ff a7 ff a7 ff                      
+ConditionValueB = a18: 00 00 00 00 00 00 00 00 00 00 05 00 05 00 05 00 05 00                      
+ConditionValueC = a18: a1 00 db 00 01 00 00 00 03 00 80 00 40 00 02 00 00 00                      
+
+
+
+
+;0x29e97                                                                                                                                                                                    
+;  call	ir_main                                                                                                                                                                              
+; 	ld	d,a			; IR_STAT                                                                             
+;	xor	a                                                                                                                     
+                                                                                                                            
+                                                                                                                            
+;   _IRcomm_end   0x2a1b9                                                                                                   
+; ld	hl,ir_read_buf                |       21 50 c7                                                    
+;	ld	de,ir_read_buf_stk            |       11 00 c8                                                    
+;	ld	bc,15                         |                                                                                       
+;	call	block_move                  |                                                                                       
+;                                   |                                                                                       
+;00104bf8h: FE 03 30 24        
+;00104bf0h: FE 03 30 24 3E 41 21 0B 51 CF CD FB 50          ; ?0$>A!.Q贤鸓    
+;00104bf0h: FE 03 30 24 3E 41 21 0B 51 CF CD FB 50          ; ?0$>A!.Q贤鸓                                                                                                                                                                                                                                                                                                                                     
+;the code below is Set_send_data2                                                                                                                                       
+;           3E 41 21 0A 51 CF CD FA 50 
+;           3E 41 21 0B 51 CF CD FB 50                                                                                                                                                                                                                                                                                                                                    
+; ------->                                                                                                                  
+; BCALL	G_BANK0b,set_send_data2                                                                         
+;	call	read_buf_clr                                                                                                        
+;                                                                                                                           
+                                                                                                                                                                          
+;001048dbh: 3E 02 EA 01 CA 3E 14 EA 02 CA F0 FF F5 CD 94 4A        
+;001048dbh: 3E 02 EA 01 CA 3E 14 EA 02 CA F0 FF F5 CD 9D 4A                           
+[infrared fake 0]                                                                                                           
+Mode = 1                                                                                                                    
+Address = {{address}}                                                                                  
+Fixcode={{Patch::big}}                                                                                   
+                                                                                                                            
+               
+;00104c3ch: CD 66 4D CD 9E 4D CD E5 4D F0 BC FE 10 CA 24 4D   
+;00104a95h: F3 3E 3A 21 E9 4F CF CD 5E 4D CD 96 4D CD DD 4D ; ?:!镺贤^M蜄M洼M
+;00104a9ch: CD 5E 4D CD 96 4D CD DD 4D F0 BC FE 10          ; 蚟M蜄M洼M鸺?                                                                
+                                                                                                                     
+[infrared fake 1]                                                                                                    
+Mode = 1                                                                                                             
+Address = {{address}}                                                                                              
+Fixcode={{patch::big}}                                           
+                                                                                                                     
+[infrared fake 2]                                                                                                    
+Mode = 2                                                                                                             
+Address = {{address}}                                                                            
+Type = 101                                                                                                           
+                                                                                                                                                                                          
+[infrared fake 3]                    
+Mode = 2                             
+Address = {{address}}                 
+Type = 102                           
+                                     
+[infrared fake 4]                    
+Mode = 2                             
+Address = {{address}}           
+Type = 103                           
+
+
+;/////////////
+;////fpa////////
+;/////////rangel zhang ///////////
+
+;PC:51-4118=20 000CC118  LY:012 AF:00A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFC1
+;PC:51-411A=FA 000CC11A  LY:012 AF:00A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFC1
+;PC:51-411D=CB 000CC11D  LY:012 AF:61A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFC1
+;PC:51-411F=20 000CC11F  LY:012 AF:61A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFC1
+;PC:51-4121=CD 000CC121  LY:012 AF:61A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFC1
+;PC:51-417A=CD 000CC17A  LY:012 AF:61A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFBF
+;PC:51-41CA=3E 000CC1CA  LY:012 AF:61A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFBD
+;PC:51-41CC=EA 000CC1CC  LY:012 AF:01A0 BC:E400 DE:E4E4 HL:FFA0 SP:DFBD
+
+;ROM:CC118                 jr      nz, unk_C14D  
+;ROM:CC11A                 ld      a, [byte_D1AB]
+;ROM:CC11D                 bit     7, a          
+;ROM:CC11F                 jr      nz, unk_C138  
+;ROM:CC121                 call    unk_417A      
+;ROM:CC124                 call    unk_415A      
+;ROM:CC127                 call    unk_47F7    
+
+;000cc13eh: 6F 26 00 11                                     ; o&.. 
+;000cc156h: 6F 26 00 11                                     ; o&.. 
+;000cc137h: 38 17 CD 92 41 CD 72 41 CD 95 48 CD D3 41 AF E0 ; 8.蛼A蛂A蜁H陀A
+;000cc128h: 38 17 CD A1 41 CD 63 41 CD A4 48 CD E2 41 AF E0 ; 8.汀A蚦A亭H外A
+
+;the 7th bit of the  [byte_D1AB],decide whether the animation should be played.
+;if it's zero , the game code will play fighting animation . otherwise, game code 
+; will jump to unk_C138 and avoiding playing animation.
+; so we can begin out FPA patch right at address 0xcc121 .      
+
+
+;DarkEnable0 = 0	;0:Off, 1:On (for Normal Mode)
+;ReduceEnable0 = 0	;0:Off, 1:On (for Normal Mode)
+;MotionBEnable0 = 0	;0:Off, 1:Black Fade, 2:, 3:Frame Blend (for Normal Mode)
+;Dark0 = 10		;0~10 (for Normal Mode)
+;012532
+;
+[FPA 001 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}}
+DarkEnable0 = 1
+Dark0 = 4  
+MotionBEnable0 = 3                                            
+MotionBlur0 = 11                                                                                                         
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:FISSURE}} 00
+
+;ROM:35D09                 ld      [byte_CFB6], a
+;ROM:35D0C                 ld      a, d
+;ROM:35D0D                 ld      [byte_CFB7], a
+;ROM:35D10                 ld      c, 3
+;ROM:35D12                 call    unk_468
+;ROM:35D15                 ld      hl, $40E5
+;ROM:35D18                 ld      a, $33 ; '3'
+;ROM:35D1A                 rst     8
+;ROM:35D1B                 ret
+;           EA B6 CF 7A EA B7 CF 0E 03 CD 68 04 21 E5 40 3E       
+;00035d09h: EA C2 CF 7A EA C3 CF 0E 03 CD 68 04 21 D6 40 3E 
+;00035d09h: EA C2 CF 7A EA C3 CF 0E 03 CD 68 04 21 D8 40 3E
+
+;******dc7d---------------   Mem Write: pc32 = 0x30a7 addr = 0xd066 value = 0x2c
+;******dc7d---------------   Mem Write: pc32 = 0x30a7 addr = 0xd067 value = 0x3a
+;******dc7d---------------   Mem Write: pc32 = 0x30a7 addr = 0xd068 value = 0xb8
+;******dc7d---------------   Mem Write: pc32 = 0x30a7 addr = 0xd069 value = 0x50
+; ------------   Mem Write: pc32 = 0x35d09 addr = 0xcfb6 value = 0x78
+;s e l   d e s c  
+;
+
+[FPA 002 Begin]                                                   
+Mode = 3                                                          
+Type = 0      
+Address = {{address}}  
+DarkEnable0 = 1
+Dark0 = 4 
+MotionBEnable0 = 3                                            
+MotionBlur0 = 11                                               
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:SELFDESTRUCT}} 00
+
+
+; lightening    
+; --------------   Mem Write: pc32 = 0x35d09 addr = 0xcfb6 value = 0x57
+[FPA 003 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}}   
+DarkEnable0 = 1
+Dark0 = 4  
+MotionBEnable0 = 3                                            
+MotionBlur0 = 15                                               
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf  
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:THUNDER}} 00      
+                                             
+
+
+
+;ji wa lei  011800
+
+[FPA 004 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}} 
+DarkEnable0 = 1
+Dark0 = 4   
+MotionBEnable0 = 3                                            
+MotionBlur0 = 15                                          
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf  
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:FLASH}} 00
+
+
+;skill name 1 : ..............Mem Write: pc32 = 0x30db addr = 0xcf87 value = 0x2c
+;skill name 2 : ..............Mem Write: pc32 = 0x30db addr = 0xcf88 value = 0x3a
+;skill name 3 : ..............Mem Write: pc32 = 0x30db addr = 0xcf89 value = 0xb8
+;skill name 4 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8a value = 0x50
+;skill name 5 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8b value = 0x8f
+;skill name 6 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8c value = 0x9d
+; include 2 pieces of animationl.
+;ji ba lu  011607
+
+[FPA 005 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}}   
+DarkEnable0 = 1
+Dark0 = 4  
+MotionBEnable0 = 3                                            
+MotionBlur0 = 15                                                   
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf  
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:EXPLOSION}} 00
+
+
+;skill name 1 : ..............Mem Write: pc32 = 0x30db addr = 0xcf87 value = 0x30
+;skill name 2 : ..............Mem Write: pc32 = 0x30db addr = 0xcf88 value = 0xb2
+;skill name 3 : ..............Mem Write: pc32 = 0x30db addr = 0xcf89 value = 0x3a
+;skill name 4 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8a value = 0xb8
+;skill name 5 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8b value = 0xca
+;skill name 6 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8c value = 0xc2 
+; da yi ba ha ku ci   011441
+    
+[FPA 006 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}}   
+DarkEnable0 = 1
+Dark0 = 4  
+MotionBEnable0 = 3                                            
+MotionBlur0 = 11                                              
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf  
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:HORN_DRILL}} 00
+
+
+
+;skill name 1 : ..............Mem Write: pc32 = 0x30db addr = 0xcf87 value = 0x9b
+;skill name 2 : ..............Mem Write: pc32 = 0x30db addr = 0xcf88 value = 0xa5
+;skill name 3 : ..............Mem Write: pc32 = 0x30db addr = 0xcf89 value = 0xac
+;skill name 4 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8a value = 0x8b
+;skill name 5 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8b value = 0xae
+;skill name 6 : ..............Mem Write: pc32 = 0x30db addr = 0xcf8c value = 0x50
+;    011251
+;    
+[FPA 007 Begin]                                                   
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}}   
+DarkEnable0 = 1
+Dark0 = 5   
+MotionBEnable0 = 3                                            
+MotionBlur0 = 7                                              
+ConditionType = 0                                                 
+ConditionValueA = a2: c2 cf  
+ConditionValueB = a2: 00 00
+ConditionValueC = a2: {{constant:constants/move_constants.asm:HYPER_BEAM}} 00                                                          
+
+
+                        
+                                                                                                                            
+;-----111111111111111144444444444444----0xc902 no ..............Mem Write: pc32 = 0xcc46a addr = 0xc902 value = 0xd                              
+                                      
+;000cc473h: FE 4F D0 cd                                        ; 﨩?    
+;000cc495h: FE 4F D0 CD                                     ; 﨩型
+;000cc497h: FE 4F D0 CD                                     ; 﨩型
+; -------------0xd4170xd4170xd4170xd417---------------   Mem Write: pc32 = 0x3a89 addr = 0xd417 value = 0xd1
+;000cc486h: FE 4F D0 CD 7D 3A 22 FA 19 D4 22 C5 E5 6F 26 00 ; 﨩型}:"??佩o&.                                                                                                                                                    
+[FPA 042801 Begin]                                                                                                                               
+Mode = 3                                                                                                                                         
+Type = 0                                                                                                                                         
+Address = {{Address}}                                                                                                                       
+DarkEnable0 = 1                                                                                                                                  
+Dark0 = 5                                                                                                                                        
+MotionBEnable0 = 3                                                                                                                               
+MotionBlur0 = 11                                                                                                                                 
+ConditionType = 0                                                                                                                                
+ConditionValueA = a4: c2 cf 17 d4                                                                              
+ConditionValueB = a4: 00 00 00 00                                                                                 
+ConditionValueC = a4: d9 00 d1 00                                                                                 
+
+    
+
+
+;ROM:CC139                 call    unk_4192
+;ROM:CC13C                 call    unk_4172
+;ROM:CC13F                 call    unk_4895
+;ROM:CC142                 call    unk_41D3
+;ROM:CC145                 xor     a       
+
+;ROM:CC154                 jr      z, unk_C16E
+;ROM:CC156                 ld      l, a
+;ROM:CC157                 ld      h, 0
+;ROM:CC159                 ld      de, $10E
+;ROM:CC15C                 add     hl, de
+;ROM:CC15D                 ld      a, l
+; CC156  6F 26 00 11 0E 01  
+
+; 000cc147h: 6F 26 00 11 0E 01                               ; o&....
+
+;exit point
+
+[FPA 001 End]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{address}}  
+
+
+;-----ddddff0xff690xff69fffff----0xffa0 no ....-------------..........Mem Write: pc32 = 0x8c352 addr = 0xffa0 value = 0x1
+;-----ddddff0xff690xff69fffff----0xce57 no ....----5555555577777---------..........Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x1a
+;0008c352h: 36 01 FA 57 CE CB 7F 20 08                      ; 6.鶺嗡 .
+;0008c229h: 36 01 FA 57 CF CB 7F 20 08 CD 14 43 CD 5A 04 18 ; 6.鶺纤 .?C蚙..   
+[FPA link fight begin]
+Mode = 3                                                          
+Type = 0                                                          
+Address = {{address}} 
+DarkEnable0 = 1
+Dark0 = 5  
+MotionBEnable0 = 3                                            
+MotionBlur0 = 11                              
+
+;-----ddddff0xff690xff69fffff----0xffa0 no ....-------------..........Mem Write: pc32 = 0x8c382 addr = 0xffa0 value = 0x0   
+;0008c382h: E0 A0 CD 2E 03 C9                               ; 酄?.?  
+;******ccccccccccceeeeeeeeeee55555555577777777---------------   Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x15
+;******ccccccccccceeeeeeeeeee55555555577777777---------------   Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x16
+;******ccccccccccceeeeeeeeeee55555555577777777---------------   Mem Write: pc32 = 0x8c483 addr = 0xce57 value = 0x17
+
+;40 90 e4 01 3E at 3E     
+;0008c3e4h: 40 90 E4 01 3E     at 3E                                ; @愪.>
+[FPA link fight End0]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{ADDREss}}
+
+;3D 20 EF C9 3E 01 at 3E      
+; 0008c439h: 3D 20 EF C9 3E       at 3e                           ; = 锷>
+[FPA link fight End1]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{ADDREss}}
+
+;01 FF 3E 01 at 3E
+;0008c576h: 01 FF 3E 01                                     ; .>.
+[FPA link fight End2]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{ADDREss}}
+
+;32 00 19 00 3e 01 at 3e
+;0008c764h: 32 00 19 00 3E 01                               ; 2...>.
+[FPA link fight End3]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{ADDREss}}
+ 
+;ROM:8C25A                 ld      [byte_FFC6], a
+;ROM:8C25C                 ld      [byte_FFC7], a
+;ROM:8C25E                 ld      [byte_FFC8], a
+;ROM:8C260                 ld      [byte_FFD0], a
+;ROM:8C262                 ld      a, 1
+;ROM:8C264                 ld      [byte_FF70], a
+;ROM:8C266                 pop     af
+;ROM:8C267                 ld      [byte_FF9E], a        --------------------at here .
+;ROM:8C269                 call    unk_45A
+;ROM:8C26C                 ret
+ 
+ 
+;ROM:8C298                 xor     a         searching code : AF 22 22 77 CD  
+;ROM:8C299                 ldi     [hl], a             
+;ROM:8C29A                 ldi     [hl], a
+;ROM:8C29B                 ld      [hl], a
+;ROM:8C29C                 call    unk_46D8
+;ROM:8C29F                 ret
+;0008c298h: AF 22 22 77 CD                                  ; ?"w? 
+
+
+[FPA link fight End4]                                                     
+Mode = 3                                                          
+Type = 1                                                          
+Address = {{address}}                       

--- a/roms.sha1
+++ b/roms.sha1
@@ -1,2 +1,3 @@
 f4cd194bdee0d04ca4eac29e09b8e4e9d818c133 *pokecrystal.gbc
 f2f52230b536214ef7c9924f483392993e226cfb *pokecrystal11.gbc
+a25517f60ca0e887d39ec698aa56a0040532a4b3  pokecrystalvc.patch

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -6,3 +6,4 @@ png_dimensions
 pokemon_animation
 pokemon_animation_graphics
 scan_includes
+make_patch

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,7 +11,8 @@ tools := \
 	pokemon_animation \
 	pokemon_animation_graphics \
 	gfx \
-	md5
+	md5 \
+	make_patch
 all: $(tools)
 	@:
 

--- a/tools/make_patch.c
+++ b/tools/make_patch.c
@@ -1,0 +1,824 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+#include <ctype.h>
+
+struct symbol {
+	struct symbol *next;
+	unsigned int value;
+	char name[];
+};
+
+struct patch {
+	unsigned int offset;
+	unsigned int size;
+};
+
+struct buffer {
+	size_t size;
+	char buffer[];
+};
+
+struct asmfile {
+	struct asmfile *next;
+	struct symbol *symbols;
+	char name[];
+};
+
+struct asmfile *asmfiles = NULL;
+
+void free_buffer(void *buf)
+{
+	struct buffer *buffer = buf - sizeof(struct buffer);
+	free(buffer);
+}
+
+void *create_buffer()
+{
+	struct buffer *buffer = malloc(sizeof(struct buffer) + 0x100);
+	if (!buffer) {
+		fprintf(stderr, "Error: Cannot allocate memory\n");
+		return NULL;
+	}
+
+	buffer->size = 0x100;
+	return buffer->buffer;
+}
+
+void *expand_buffer(void *buf, const size_t size)
+{
+	struct buffer *buffer = buf - sizeof(struct buffer);
+
+	if (size > buffer->size) {
+		buffer = realloc(buffer, (buffer->size += 0x100));
+		if (!buffer) {
+			free_buffer(buf);
+			fprintf(stderr, "Error: Cannot allocate memory\n");
+			return NULL;
+		}
+	}
+
+	return buffer->buffer;
+}
+
+void free_list(void *list)
+{
+	// Frees an entire linked list
+	// Expects the ->next entry to be the first element!
+
+	while (list) {
+		void *next = *(void **)list;
+		free(list);
+		list = next;
+	}
+}
+
+void free_asmfiles(struct asmfile *asmfile)
+{
+	void *temp;
+	while (asmfile) {
+		if (asmfile->symbols) free_list(asmfile->symbols);
+		temp = asmfile;
+		asmfile = asmfile->next;
+		free(temp);
+	}
+}
+
+int create_symbol(struct symbol **tip, const int value, const char *name)
+{
+	struct symbol *symbol;
+
+	symbol = malloc(sizeof(struct symbol) + strlen(name) + 1);
+	if (!symbol) {
+		fprintf(stderr, "Error: Cannot allocate memory\n");
+		return -1;
+	}
+	symbol->value = value;
+	strcpy(symbol->name, name);
+
+	// Link it at the start of the rest of the list
+	symbol->next = *tip;
+	*tip = symbol;
+
+	return 0;
+}
+
+const struct symbol *find_symbol(const struct symbol *symbols, const char *name)
+{
+	const struct symbol *symbol = symbols;
+	while (symbol) {
+		if (strcmp(symbol->name, name) == 0) {
+			return symbol;
+		}
+		symbol = symbol->next;
+	}
+
+	return NULL;
+}
+
+int parse_address(char *buffer)
+{
+	int offset;
+	int bank, address;
+	char *endptr_bank, *endptr_address;
+	char *buffer_address;
+
+	buffer_address = strchr(buffer, ':');
+	if (buffer_address) *buffer_address++ = '\0';
+
+	// Verify it consists of expected elements
+	if (strlen(buffer) > 2 || !buffer_address || strlen(buffer_address) > 4) {
+		if (buffer_address) *--buffer_address = ':';
+		fprintf(stderr, "Error: Unexpected %s\n", buffer);
+		return -1;
+	}
+
+	// Parse the bank and address parts
+	bank = strtol(buffer, &endptr_bank, 16);
+	address = strtol(buffer_address, &endptr_address, 16);
+	if (endptr_bank != buffer + strlen(buffer) ||
+			endptr_address != buffer_address + strlen(buffer_address)) {
+		fprintf(stderr, "Error: Cannot parse %s:%s\n", buffer, buffer_address);
+		return -1;
+	}
+
+	// If it's not a ROM address, (silently) ignore it.
+	if (address > 0x7FFF) return 0;
+
+	// Calculate the absolute offset in the ROM
+	if (bank == 0) {
+		offset = address;
+	} else {
+		offset = bank * 0x4000 + (address - 0x4000);
+	}
+
+	return offset;
+}
+
+struct symbol *parse_symfile(FILE *file, const char *prefix)
+{
+	struct symbol *symbols = NULL;
+	char *buffer;
+	size_t buffer_index = 0;
+	int c;
+	int offset = -1;
+
+	buffer = create_buffer();
+	if (!buffer) goto error;
+
+	// Parse the symfile, to get the symbols we want.
+	while ((c = getc(file)) != EOF) {
+		buffer = expand_buffer(buffer, buffer_index);
+		if (!buffer) goto error;
+
+		switch (c) {
+		case ';':
+		case '\n':
+			// If we encounter a newline or comment,
+			//   we've reached the end of the label name.
+			buffer[buffer_index] = '\0';
+
+			// Only do stuff if we managed to read a valid offset.
+			if (offset == -1 && buffer_index > 0) {
+				fprintf(stderr, "Error: Cannot parse %s\n", buffer);
+				goto error;
+			}
+
+			// This is the end of the parsable line
+			buffer_index = SIZE_MAX;
+			if (offset == -1) break;
+
+			// Check if the symbol starts with the requested prefix
+			if (strncmp(prefix, buffer, strlen(prefix)) != 0) break;
+
+			if (create_symbol(&symbols, offset, buffer + strlen(prefix))) goto error;
+
+			offset = -1;
+			break;
+
+		case '.':
+			// If a local symbol has been requested,
+			//   we can clear the buffer at the first '.'
+			if (offset != -1 && prefix[0] == '.' && buffer[0] != '.') {
+				buffer_index = 0;
+			}
+
+			buffer[buffer_index++] = c;
+			break;
+
+		case ' ':
+			// If we've just encountered a space, ignore this one
+			if (offset != -1) {
+				if (buffer_index) {
+					buffer[buffer_index++] = c;
+				}
+				break;
+			}
+
+			// If we encounter a space, we've reached the end of the address.
+			buffer[buffer_index] = '\0';
+			offset = parse_address(buffer);
+			if (offset == -1) goto error;
+			buffer_index = offset ? 0 : SIZE_MAX;
+
+			break;
+
+		default:
+			buffer[buffer_index++] = c;
+		}
+
+		// We were requested to skip to the next line
+		if (buffer_index == SIZE_MAX) {
+			buffer_index = 0;
+			offset = -1;
+
+			while (c != '\n') {
+				if ((c = getc(file)) == EOF) break;
+			}
+		}
+	}
+
+	if (!symbols) {
+		fprintf(stderr, "Error: No symbols found starting with: %s\n", prefix);
+	}
+
+	free_buffer(buffer);
+	return symbols;
+
+error:
+	if (buffer) free_buffer(buffer);
+	return NULL;
+}
+
+int parse_rgbds_int(char *string)
+{
+	char *start = string;
+	char *end;
+	int base = 10;
+	int value;
+
+	// Figure out the base
+	if (*start == '$') {
+		base = 16;
+		start++;
+	}
+
+	errno = 0;
+	value = strtol(start, &end, base);
+
+	if (errno || end != string + strlen(string)) {
+		// Parsing complex things is out of this program's scope.
+		// Warning the user would be a good thing, but warning
+		//  for things we just can't parse would be annoying...
+		return -1;
+	}
+
+	return value;
+}
+
+struct symbol *parse_asm(FILE *file)
+{
+	struct symbol *symbols = NULL;
+	char *label = NULL;
+	char *buffer;
+	size_t buffer_index = 0;
+	int const_value = -1;
+	int c;
+
+	enum {
+		PARSING_LABEL,
+		PARSING_INSTRUCTION,
+		PARSING_EQU,
+		PARSING_CONST_DEF,
+		PARSING_CONST
+	} parsing = PARSING_LABEL;
+
+	buffer = create_buffer();
+	if (!buffer) goto error;
+
+	// Get all the constants defined in a file
+	while ((c = getc(file)) != EOF) {
+		buffer = expand_buffer(buffer, buffer_index);
+		if (!buffer) goto error;
+
+		switch(c) {
+		case ' ':
+		case '\t':
+			// Eat these characters if we haven't picked up anything else yet
+			if (!buffer_index) {
+				// If the line starts with one of these characters,
+				//  we're parsing an instruction.
+				if (parsing == PARSING_LABEL) parsing = PARSING_INSTRUCTION;
+				break;
+			}
+
+			if (parsing == PARSING_LABEL) {
+				// A label starts with its name
+				buffer[buffer_index] = '\0';
+				buffer_index = 0;
+				label = malloc(strlen(buffer) + 1);
+				if (!label) {
+					fprintf(stderr, "Error: Cannot allocate memory\n");
+					goto error;
+				}
+				strcpy(label, buffer);
+				parsing = PARSING_INSTRUCTION;
+				break;
+			} else if (parsing == PARSING_INSTRUCTION) {
+				// Figure out what instruction we've encountered
+				buffer[buffer_index] = '\0';
+				buffer_index = SIZE_MAX;
+
+				if (label && strcmp(buffer, "EQU") == 0) {
+					buffer_index = 0;
+					parsing = PARSING_EQU;
+				} else if (strcmp(buffer, "const_def") == 0) {
+					buffer_index = 0;
+					parsing = PARSING_CONST_DEF;
+				} else if (strcmp(buffer, "const") == 0) {
+					buffer_index = 0;
+					parsing = PARSING_CONST;
+				}
+				break;
+			}
+
+			buffer[buffer_index++] = c;
+			break;
+
+		case '\n':
+		case ';':
+			buffer[buffer_index] = '\0';
+
+			// Trim ending whitespace
+			while (isspace(buffer[--buffer_index])) buffer[buffer_index] = '\0';
+			buffer_index++;
+
+			if (parsing == PARSING_INSTRUCTION) {
+				// const_def may also take 0 arguments
+				if (strcmp(buffer, "const_def") == 0) {
+					const_value = 0;
+				}
+			} else if (parsing == PARSING_EQU) {
+				int value = parse_rgbds_int(buffer);
+				if (value != -1) {
+					if (create_symbol(&symbols, value, label)) goto error;
+				}
+			} else if (parsing == PARSING_CONST_DEF) {
+				int value = parse_rgbds_int(buffer);
+				if (value != -1) {
+					const_value = value;
+				}
+			} else if (parsing == PARSING_CONST) {
+				if (const_value == -1) {
+					fprintf(stderr, "Error: Found `const` before `const_def`\n");
+					goto error;
+				}
+				if (create_symbol(&symbols, const_value++, buffer)) goto error;
+			}
+
+			buffer_index = SIZE_MAX;
+			parsing = PARSING_LABEL;
+			break;
+
+		default:
+			buffer[buffer_index++] = c;
+		}
+
+		// We were requested to skip to the next line
+		if (buffer_index == SIZE_MAX) {
+			buffer_index = 0;
+			parsing = PARSING_LABEL;
+			if (label) free(label);
+			label = NULL;
+
+			while (c != '\n') {
+				if ((c = getc(file)) == EOF) break;
+			}
+		}
+	}
+
+	free_buffer(buffer);
+	if (label) free(label);
+	return symbols;
+
+error:
+	if (buffer) free_buffer(buffer);
+	if (label) free(label);
+	return NULL;
+}
+
+int get_constant(const char *filename, const char *constant)
+{
+	int value = -1;
+	FILE *file = NULL;
+	struct symbol *symbols = NULL;
+	struct asmfile *asmfile = asmfiles;
+	const struct symbol *symbol;
+
+	// Check if we've already loaded the symbols
+	while (asmfile) {
+		if (strcmp(asmfile->name, filename) == 0) {
+			symbols = asmfile->symbols;
+			break;
+		}
+		asmfile = asmfile->next;
+	}
+
+	// If not, well, load them
+	if (!symbols) {
+		file = fopen(filename, "r");
+		if (!file) {
+			fprintf(stderr, "Error: Cannot open file: %s\n", filename);
+			goto error;
+		}
+		symbols = parse_asm(file);
+		fclose(file);
+		file = NULL;
+
+		// Save them for later re-use
+		asmfile = malloc(sizeof(struct asmfile) + strlen(filename) + 1);
+		if (!asmfile) {
+			fprintf(stderr, "Error: Cannot allocate memory\n");
+			if (symbols) free_list(symbols);
+			goto error;
+		}
+		asmfile->symbols = symbols;
+		strcpy(asmfile->name, filename);
+		asmfile->next = asmfiles;
+		asmfiles = asmfile;
+	}
+
+	// Look for the symbol
+	symbol = find_symbol(symbols, constant);
+	if (!symbol) {
+		fprintf(stderr, "Error: Could not find constant %s in file %s\n", constant, filename);
+		goto error;
+	}
+
+	value = symbol->value;
+
+error:
+	if (file) fclose(file);
+	return value;
+}
+
+void interpret_command(char *command, const struct symbol *symbol, struct patch *patch,
+                       FILE *new_rom, FILE *orig_rom, FILE *output)
+{
+	int argc = 0;
+	int offset = symbol->value;
+	char *s;
+
+	// Count the arguments
+	s = command;
+	while (*s) if (*s++ == ':') argc++;
+
+	// Get the arguments
+	char *argv[argc];
+	if ((s = strchr(command, ':'))) {
+		*s++ = '\0';
+		argv[0] = s;
+		for (int i = 1; i < argc; i++) {
+			if (!(s = strchr(s, ':'))) break;
+			*s++ = '\0';
+			argv[i] = s;
+		}
+	}
+
+	// Now we finally can do stuff with it
+	if (strcmp(command, "ADDREss") == 0) {
+		// Shitty hack, shouldn't be used anyway
+		int high = offset >> 8;
+		int low = offset & 0xFF;
+		fprintf(output, "0x%X%x", high, low);
+	} else if (strcmp(command, "Address") == 0 ||
+			   strcmp(command, "address") == 0) {
+		if (argc > 0) offset += strtol(argv[0], NULL, 0);
+
+		fprintf(output, "0x");
+		if (argc > 1) {
+			for (int i = strtol(argv[1], NULL, 0); i > 0; i--) {
+				putchar('0');
+			}
+		}
+
+		fprintf(output, isupper(command[0]) ? "%X" : "%x", offset);
+	} else if (strcmp(command, "Patch") == 0 ||
+			   strcmp(command, "patch") == 0) {
+		if (argc > 0) offset += strtol(argv[0], NULL, 0);
+
+		if (fseek(orig_rom, offset, SEEK_SET) != 0) {
+			fprintf(stderr, "Error: Could not seek to the offset of %s in the original ROM\n", symbol->name);
+			return;
+		}
+
+		if (fseek(new_rom, offset, SEEK_SET) != 0) {
+			fprintf(stderr, "Error: Could not seek to offset of %s in the new ROM\n", symbol->name);
+			return;
+		}
+
+		if (argc <= 1 || strcmp(argv[1], "big") != 0) {
+			int c = getc(new_rom);
+			if (c == getc(orig_rom)) {
+				fprintf(stderr, "Warning: %s doesn't actually contain any differences\n", symbol->name);
+			}
+
+			patch->offset = offset;
+			patch->size = 1;
+			fprintf(output, "0x");
+			fprintf(output, isupper(command[0]) ? "%02X" : "%02x", c);
+		} else {
+			int length = 0;
+
+			// Figure out the length of the patch
+			while(getc(orig_rom) == getc(new_rom)) length++;
+			length++;
+			while(getc(orig_rom) != getc(new_rom)) length++;
+
+			// We've got the length, now go back
+			fseek(new_rom, offset, SEEK_SET);
+
+			// Print out the patch
+			patch->offset = offset;
+			patch->size = length;
+			fprintf(output, "a%d:", length);
+			for (int i = 0; i < length; i++) {
+				if (i != 0) putc(' ', output);
+				fprintf(output, isupper(command[0]) ? "%02X" : "%02x", getc(new_rom));
+			}
+		}
+	} else if (strcmp(command, "Constant") == 0 ||
+			   strcmp(command, "constant") == 0) {
+		if (argc <= 1) {
+			fprintf(stderr, "Error: Missing arguments for %s", command);
+		}
+
+		int value = get_constant(argv[0], argv[1]);
+		if (value == -1) return;
+
+		fprintf(output, isupper(command[0]) ? "%X": "%x", value);
+	} else {
+		fprintf(stderr, "Error: Unknown command: %s\n", command);
+	}
+}
+
+struct patch *process_template(FILE *file, FILE *new_rom, FILE *orig_rom, FILE *output,
+                               const struct symbol *symbols)
+{
+	struct patch *patches = NULL;
+	struct patch *patch = NULL;
+	const struct symbol *symbol = NULL;
+	char *buffer;
+	size_t buffer_index = 0;
+	int c;
+	int line_pos = 0;
+
+	buffer = create_buffer();
+	if (!buffer) goto error;
+
+	patches = create_buffer();
+	if (!patches) goto error;
+	patch = patches;
+
+	// Implicitly add the ROM checksum to the patch list,
+	//   since that will always differ.
+	patch->offset = 0x14e;
+	patch->size = 2;
+	patch++;
+
+	// Fill in the template
+	while ((c = getc(file)) != EOF) {
+		buffer = expand_buffer(buffer, buffer_index);
+		if (!buffer) goto error;
+
+		switch (c) {
+		case '\n':
+			// A newline simply resets line_pos
+			putc(c, output);
+			line_pos = 0;
+			break;
+
+		case '/':
+			// Check if we've encountered a comment
+			c = getc(file);
+			if (c != '*') {
+				putc('/', output);
+				line_pos++;
+				ungetc(c, file);
+				break;
+			}
+
+			// Simply gobble everything up until we hit the end
+			while ((c = getc(file)) != EOF) {
+				if (c == '*') {
+					if ((c = getc(file)) == EOF) break;
+					if (c == '/') break;
+				}
+			}
+
+			break;
+
+		case '{':
+			// Check if we've found two of them.
+			c = getc(file);
+			if (c != '{') {
+				putc('{', output);
+				line_pos++;
+				ungetc(c, file);
+				break;
+			}
+
+			// If we have, we store the contents before it ends into buffer
+			buffer_index = 0;
+			while ((c = getc(file)) != EOF) {
+				if (c == '}') {
+					if ((c = getc(file)) == EOF) break;
+					if (c == '}') break;
+				}
+
+				buffer[buffer_index++] = c;
+				buffer = expand_buffer(buffer, buffer_index);
+				if (!buffer) goto error;
+			}
+
+			buffer[buffer_index] = '\0';
+
+			// If we didn't manage to find the symbol,
+			//   we can just end inmediately.
+			if (!symbol) break;
+
+			patch->offset = 0;
+			interpret_command(buffer, symbol, patch, new_rom, orig_rom, output);
+			if (patch->offset) patch++;
+			patches = expand_buffer(patches, (uintptr_t)patch - (uintptr_t)patches);
+			if (!patches) goto error;
+
+			break;
+
+		case '[':
+			// End inmediately if this is not the beginning of the line.
+			if (line_pos) {
+				putc(c, output);
+				line_pos++;
+				break;
+			}
+
+			// Try to read the label
+			putc(c, output);
+			buffer_index = 0;
+
+			while ((c = getc(file)) != EOF) {
+				putc(c, output);
+
+				if (c == ']') {
+					// If we're at the end, we can get the symbol for the label
+					buffer[buffer_index] = '\0';
+
+					// Translate spaces to underscores
+					for (char *p = buffer; *p != '\0'; p++) {
+						if (*p == ' ') *p = '_';
+					}
+
+					// Look for the symbol
+					symbol = find_symbol(symbols, buffer);
+					if (!symbol) {
+						fprintf(stderr, "Error: Cannot find symbol: %s\n",
+						        buffer);
+					}
+
+					// Skip until the next newline
+					while ((c = getc(file)) != EOF) {
+						putc(c, output);
+						if (c == '\n') break;
+					}
+					buffer_index = 0;
+					break;
+				}
+
+				buffer[buffer_index++] = c;
+			}
+
+			break;
+
+		default:
+			putc(c, output);
+			line_pos++;
+		}
+	}
+
+	patch->offset = 0;
+	free_buffer(buffer);
+	return patches;
+
+error:
+	if (patches) free_buffer(patches);
+	if (buffer) free_buffer(buffer);
+	return NULL;
+}
+
+int compare_patch(const void *_patch1, const void *_patch2)
+{
+	const struct patch *patch1 = _patch1;
+	const struct patch *patch2 = _patch2;
+	return patch1->offset - patch2->offset;
+}
+
+int verify_completeness(FILE *orig_rom, FILE *new_rom, struct patch *patches)
+{
+	struct patch *patch = patches;
+	size_t offset = 0;
+	int c, d;
+
+	while (patch->offset != 0) patch++;
+	qsort(patches, patch - patches, sizeof(struct patch), compare_patch);
+
+	rewind(orig_rom);
+	rewind(new_rom);
+	patch = patches;
+	for (;;) {
+		c = getc(orig_rom);
+		d = getc(new_rom);
+		if (c == EOF || d == EOF) break;
+
+		if (patch->offset && patch->offset == offset) {
+			if (fseek(orig_rom, patch->size, SEEK_CUR) != 0) return -1;
+			if (fseek(new_rom, patch->size, SEEK_CUR) != 0) return -1;
+
+			offset += patch->size + 1;
+			patch++;
+			continue;
+		}
+		offset++;
+
+		if (c != d) return -1;
+	}
+
+	return c != d;
+}
+
+int main(int argc, char *argv[])
+{
+	struct symbol *symbols = NULL;
+	struct patch *patches = NULL;
+	FILE *file = NULL;
+	FILE *new_rom = NULL;
+	FILE *orig_rom = NULL;
+
+	if (argc < 6) {
+		fprintf(stderr, "Usage: %s <label prefix> <symfile> <patched rom> <original rom>\n", argv[0]);
+		return 1;
+	}
+
+	file = fopen(argv[2], "r");
+	if (!file) {
+		fprintf(stderr, "Error: Cannot open file: %s\n", argv[2]);
+		goto error;
+	}
+
+	if (!(symbols = parse_symfile(file, argv[1]))) goto error;
+
+	fclose(file);
+	file = NULL;
+
+	new_rom = fopen(argv[3], "r");
+	if (!new_rom) {
+		fprintf(stderr, "Error: Cannot open file: %s\n", argv[3]);
+		goto error;
+	}
+
+	orig_rom = fopen(argv[4], "r");
+	if (!orig_rom) {
+		fprintf(stderr, "Error: Cannot open file: %s\n", argv[4]);
+		goto error;
+	}
+
+	file = fopen(argv[5], "r");
+	if (!file) {
+		fprintf(stderr, "Error: Cannot open file: %s\n", argv[5]);
+		goto error;
+	}
+
+	if (!(patches = process_template(file, new_rom, orig_rom, stdout, symbols))) goto error;
+	if (verify_completeness(orig_rom, new_rom, patches)) {
+		fprintf(stderr, "Warning: Not all differences in the ROM are defined in the patch\n");
+	}
+
+	free_asmfiles(asmfiles);
+	free_list(symbols);
+	fclose(file);
+	fclose(new_rom);
+	fclose(orig_rom);
+
+	return 0;
+
+error:
+	free_asmfiles(asmfiles);
+	free_list(symbols);
+	if (file) fclose(file);
+	if (new_rom) fclose(new_rom);
+	if (orig_rom) fclose(orig_rom);
+
+	return 1;
+}


### PR DESCRIPTION
This commit adds a program that is to aid in "fixing" the patches
provided by nintendo in their Virtual Console releases, as well as
potentially expanding upon them.

In doing so, @mid-kid disassembled the patch found in the Pokémon Crystal
Virtual Console release.

Of note is that this Virtual Console release has been advertised as
being able to unlock the Celebi event at the Goldenrod City Pokémon Center,
yet no patches to achieve this in the code actually exist. The emulator
handles this by editing the save file, which is fatal for a lot of ROM
hacks.